### PR TITLE
Switch to a regular `library` dub targetType

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -6,5 +6,5 @@ libs "mupdf" "mupdf-third" platform="posix"
 importPaths "source"
 
 configuration "library" {
-	targetType "sourceLibrary"
+	targetType "library"
 }


### PR DESCRIPTION
Which prevents issues with LDC (in combination with dpp-generated .d files) and reggae (which doesn't properly support sourceLibraries).

The net effect is that dub compiles the few .d files here separately now, *not* inlining them as source files into each project depending on mupdf-d (and so compiling them with the other modules in one compiler invocation by default).